### PR TITLE
Adaptive defense-dropping moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This is my first romhack, and my goal with it was to build on the Pokemon Emeral
 Physical/special split is great for the later generations, but this is an alternate idea I wanted to try that mixes up the original battle system just enough to fix Pokemon that were stunted by their typing not synergizing with their stats. You’re welcome, Flareon. And Gengar.
 * When a Pokemon gets Same-Type Attack Bonus, the move is converted to physical or special to use the Pokemon’s higher attack stat. The higher attack stat is determined after boosts from abilities and items but before stat changes and the Attack drop from burn.
 * For balance, Overheat and Psycho Boost lower whichever attack stat they use, and Superpower likewise lowers attack and defense stats adaptively.
+* (v1.0.1) Acid, Iron Tail, Rock Smash, Crush Claw, Psychic, Crunch, Shadow Ball, and Luster Purge lower the foe's corresponding defense stat based on whether the move is physical or special.
 * I haven’t tested this with Counter/Mirror Coat, but I believe they still function based on the type of the move, regardless of whether it was converted.
 ## Battle Palace Format
 I think most would agree that the Battle Palace format is boring at best. You’re at the mercy of random move selection, even if you can set your team up for better odds of getting the outcome you want. I reworked it into something that’s maybe not as flavorful but mechanically more engaging.

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2496,6 +2496,7 @@ void SetMoveEffect(bool8 primary, u8 certain)
         }
         else
         {
+            u8 moveEffect = gBattleCommunication[MOVE_EFFECT_BYTE];
             u8 side;
             switch (gBattleCommunication[MOVE_EFFECT_BYTE])
             {
@@ -2632,15 +2633,18 @@ void SetMoveEffect(bool8 primary, u8 certain)
                     gBattlescriptCurrInstr = BattleScript_StatUp;
                 }
                 break;
-            case MOVE_EFFECT_ATK_MINUS_1:
             case MOVE_EFFECT_DEF_MINUS_1:
+            case MOVE_EFFECT_SP_DEF_MINUS_1:
+                if(FlagGet(FLAG_DID_PHYSICAL_MOVE))
+                    moveEffect = MOVE_EFFECT_DEF_MINUS_1;
+                else moveEffect = MOVE_EFFECT_SP_DEF_MINUS_1;
+            case MOVE_EFFECT_ATK_MINUS_1:
             case MOVE_EFFECT_SPD_MINUS_1:
             case MOVE_EFFECT_SP_ATK_MINUS_1:
-            case MOVE_EFFECT_SP_DEF_MINUS_1:
             case MOVE_EFFECT_ACC_MINUS_1:
             case MOVE_EFFECT_EVS_MINUS_1:
                 if (ChangeStatBuffs(SET_STAT_BUFF_VALUE(1) | STAT_BUFF_NEGATIVE,
-                                    gBattleCommunication[MOVE_EFFECT_BYTE] - MOVE_EFFECT_ATK_MINUS_1 + 1,
+                                    moveEffect - MOVE_EFFECT_ATK_MINUS_1 + 1,
                                      affectsUser, 0))
                 {
                     gBattlescriptCurrInstr++;

--- a/src/data/text/move_descriptions.h
+++ b/src/data/text/move_descriptions.h
@@ -203,7 +203,7 @@ static const u8 sDisableDescription[] = _(
 
 static const u8 sAcidDescription[] = _(
     "Sprays a hide-melting acid.\n"
-    "May lower DEFENSE.");
+    "May lower defenses.");
 
 static const u8 sEmberDescription[] = _(
     "A weak fire attack that may\n"
@@ -375,7 +375,7 @@ static const u8 sConfusionDescription[] = _(
 
 static const u8 sPsychicDescription[] = _(
     "A powerful psychic attack\n"
-    "that may lower SP. DEF.");
+    "that may lower defenses.");
 
 static const u8 sHypnosisDescription[] = _(
     "A hypnotizing move that\n"
@@ -923,7 +923,7 @@ static const u8 sSweetScentDescription[] = _(
 
 static const u8 sIronTailDescription[] = _(
     "Attacks with a rock-hard\n"
-    "tail. May lower DEFENSE.");
+    "tail. May lower defenses.");
 
 static const u8 sMetalClawDescription[] = _(
     "A claw attack that may\n"
@@ -967,7 +967,7 @@ static const u8 sSunnyDayDescription[] = _(
 
 static const u8 sCrunchDescription[] = _(
     "Crunches with sharp fangs.\n"
-    "May lower SP. DEF.");
+    "May lower defenses.");
 
 static const u8 sMirrorCoatDescription[] = _(
     "Counters the foe's special\n"
@@ -987,7 +987,7 @@ static const u8 sAncientPowerDescription[] = _(
 
 static const u8 sShadowBallDescription[] = _(
     "Hurls a black blob that may\n"
-    "lower the foe's SP. DEF.");
+    "lower the foe's defenses.");
 
 static const u8 sFutureSightDescription[] = _(
     "Heightens inner power to\n"
@@ -995,7 +995,7 @@ static const u8 sFutureSightDescription[] = _(
 
 static const u8 sRockSmashDescription[] = _(
     "A rock-crushing attack\n"
-    "that may lower DEFENSE.");
+    "that may lower defenses.");
 
 static const u8 sWhirlpoolDescription[] = _(
     "Traps and hurts the foe in\n"
@@ -1102,7 +1102,7 @@ static const u8 sIngrainDescription[] = _(
     "The user can't switch out.");
 
 static const u8 sSuperpowerDescription[] = _(
-    "Boosts strength sharply,\n"
+    "A high-power strike,\n"
     "but lowers abilities.");
 
 static const u8 sMagicCoatDescription[] = _(
@@ -1179,7 +1179,7 @@ static const u8 sTailGlowDescription[] = _(
 
 static const u8 sLusterPurgeDescription[] = _(
     "Attacks with a burst of\n"
-    "light. May lower SP. DEF.");
+    "light. May lower defenses.");
 
 static const u8 sMistBallDescription[] = _(
     "Attacks with a flurry of\n"
@@ -1223,7 +1223,7 @@ static const u8 sPoisonFangDescription[] = _(
 
 static const u8 sCrushClawDescription[] = _(
     "Tears at the foe with sharp\n"
-    "claws. May lower DEFENSE.");
+    "claws. May lower defenses.");
 
 static const u8 sBlastBurnDescription[] = _(
     "Powerful, but leaves the\n"
@@ -1258,8 +1258,8 @@ static const u8 sAirCutterDescription[] = _(
     "High critical-hit ratio.");
 
 static const u8 sOverheatDescription[] = _(
-    "Allows a full-power attack,\n"
-    "but sharply lowers SP. ATK.");
+    "Allows a full-power blow,\n"
+    "but lowers the user's attack.");
 
 static const u8 sOdorSleuthDescription[] = _(
     "Negates the foe's efforts\n"
@@ -1414,8 +1414,8 @@ static const u8 sDoomDesireDescription[] = _(
     "attack 2 turns later.");
 
 static const u8 sPsychoBoostDescription[] = _(
-    "Allows a full-power attack,\n"
-    "but sharply lowers SP. ATK.");
+    "Allows a full-power blow,\n"
+    "but lowers the user's attack.");
 
 // MOVE_NONE is ignored in this table. Make sure to always subtract 1 before getting the right pointer.
 const u8 *const gMoveDescriptionPointers[MOVES_COUNT - 1] =


### PR DESCRIPTION
## “STAB Split”
* (v1.0.1) Acid, Iron Tail, Rock Smash, Crush Claw, Psychic, Crunch, Shadow Ball, and Luster Purge lower the foe's corresponding defense stat based on whether the move is physical or special.